### PR TITLE
Fix erroneous Fallout 3 dialog label

### DIFF
--- a/flmm/Games/FalloutNewVegas/FalloutNewVegasGameMode.cs
+++ b/flmm/Games/FalloutNewVegas/FalloutNewVegasGameMode.cs
@@ -970,7 +970,7 @@ namespace Fomm.Games.FalloutNewVegas
         "Fallout's registry entry appears to be missing or incorrect." + Environment.NewLine +
         "Please enter the path to your Fallout: New Vegas game file, or click \"Auto Detect\" to search" +
         " for the install directory. Note that Auto Detection can take several minutes.",
-        "Fallout 3 Game Directory:",
+        "Fallout: New Vegas Game Directory:",
         new[]
         {
           "falloutNV.exe", "falloutNVng.exe"


### PR DESCRIPTION
If the user chooses NV at launch and the registry entry is missing, [this dialog appears](http://i.imgur.com/JYkw9xm.png) which asks the user for the **Fallout 3** game directory instead of New Vegas