### PR TITLE
Fixed crash when detecting UAC on Windows 10.

### DIFF
--- a/flmm/Util/UacUtil.cs
+++ b/flmm/Util/UacUtil.cs
@@ -117,17 +117,6 @@ namespace Fomm.Util
     private static extern bool CloseHandle(IntPtr hObject);
 
     /// <summary>
-    ///   Loads the specified library.
-    /// </summary>
-    /// <param name="lpFileName">The library to load.</param>
-    /// <returns>A handle to the loaded library.</returns>
-    [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = false)]
-    public static extern IntPtr LoadLibrary(string lpFileName);
-
-    [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = true)]
-    public static extern IntPtr GetProcAddress(IntPtr hmodule, string procName);
-
-    /// <summary>
     ///   Gets whether the OS has UAC.
     /// </summary>
     /// <value>Whether the OS has UAC.</value>
@@ -135,13 +124,9 @@ namespace Fomm.Util
     {
       get
       {
-        //TODO: check for native C# way to check this out
-        var hmodule = LoadLibrary("kernel32");
-
-        //a function that only exists on Vista and above
-        // this is a hack, as the function we use may not exist on some future OS
-        var strFunction = "CreateThreadpoolWait";
-        return ((hmodule.ToInt64() != 0) && (GetProcAddress(hmodule, strFunction).ToInt64() != 0));
+        // UAC exists in Vista and later.
+        var versionVista = new Version(6, 0);
+        return Environment.OSVersion.Version >= versionVista;
       }
     }
 


### PR DESCRIPTION
This fixes the UAC detection that is causing a crash on Windows 10.  Specifically the crash detailed in Issue #46.  You can test for Vista or later by simply looking at `Environment.OSVersion`.  Note, that since FOMM isn't manifested for Windows 8.1 or Windows 10, `Environment.OSVersion` will return the Windows 8 version value and not Windows 10 (as covered in [Targeting your application for Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx)).  This doesn't matter for this test.